### PR TITLE
Use the headless build of the emulator

### DIFF
--- a/.kokoro/deploy-build-test.sh
+++ b/.kokoro/deploy-build-test.sh
@@ -30,6 +30,7 @@ if [ ! -d ${HOME}/android-sdk ]; then
 fi
 
 export ANDROID_HOME="${HOME}/android-sdk"
+export adb_command="$ANDROID_HOME"'/platform-tools/adb'
 # Install Android SDK, tools, and build tools API 27, system image, and emulator
 echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager \
     "platforms;android-27" "tools" "platform-tools" "build-tools;27.0.3" \
@@ -48,7 +49,7 @@ echo ""
 echo "Start the emulator…"
 cd ${ANDROID_HOME}/emulator
 emulator -avd test -no-audio -no-window -screen no-touch &
-adb wait-for-device
+$adb_command wait-for-device
 
 echo "Setting up speech translation microservice…"
 
@@ -77,10 +78,10 @@ cp ${KOKORO_GFILE_DIR}/google-services.json app/google-services.json
 cp ${KOKORO_GFILE_DIR}/speech_translation_test.xml app/src/main/res/values/speech_translation.xml
 
 echo "Run tests and build APK file…"
-# adb logcat --clear
-# adb logcat v long > logcat_sponge_log &
+$adb_command logcat --clear
+$adb_command logcat v long > logcat_sponge_log &
 ./gradlew clean check build connectedAndroidTest
-# adb logcat --clear
+$adb_command logcat --clear
 
 echo "Delete the Cloud Function…"
 gcloud beta functions delete speechTranslate

--- a/.kokoro/deploy-build-test.sh
+++ b/.kokoro/deploy-build-test.sh
@@ -31,10 +31,10 @@ fi
 
 export ANDROID_HOME="${HOME}/android-sdk"
 export adb_command="$ANDROID_HOME"'/platform-tools/adb'
-# Install Android SDK, tools, and build tools API 27, system image, and emulator
+# Install Android SDK, tools, and build tools API 29, system image, and emulator
 echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager \
-    "platforms;android-27" "tools" "platform-tools" "build-tools;27.0.3" \
-    "system-images;android-27;default;x86_64" "emulator"
+    "platforms;android-29" "tools" "platform-tools" "build-tools;29.0.3" \
+    "system-images;android-29;google_apis;x86_64" "emulator"
 
 export PATH=${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${PATH}
 
@@ -44,7 +44,7 @@ cp "$ANDROID_HOME"'/emulator/qemu/linux-x86_64/qemu-system-x86_64-headless' \
 
 echo "Move to the tools/bin directory…"
 cd ${ANDROID_HOME}/tools/bin
-echo "no" | ./avdmanager create avd -n test -k "system-images;android-27;default;x86_64"
+echo "no" | ./avdmanager create avd -n test -k "system-images;android-29;google_apis;x86_64"
 echo ""
 echo "Start the emulator…"
 cd ${ANDROID_HOME}/emulator

--- a/.kokoro/deploy-build-test.sh
+++ b/.kokoro/deploy-build-test.sh
@@ -55,6 +55,10 @@ echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager \
 
 export PATH=${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools:${PATH}
 
+echo "Use the headless emulator build..."
+cp "$ANDROID_HOME"'/emulator/qemu/linux-x86_64/qemu-system-x86_64-headless' \
+   "$ANDROID_HOME"'/emulator/qemu/linux-x86_64/qemu-system-x86_64'
+
 echo "Move to the tools/bin directory…"
 cd ${ANDROID_HOME}/tools/bin
 echo "no" | ./avdmanager create avd -n test -k "system-images;android-27;default;x86_64"

--- a/.kokoro/deploy-build-test.sh
+++ b/.kokoro/deploy-build-test.sh
@@ -65,7 +65,7 @@ echo "no" | ./avdmanager create avd -n test -k "system-images;android-27;default
 echo ""
 echo "Start the emulator…"
 cd ${ANDROID_HOME}/emulator
-emulator -avd test -no-audio -no-window &
+emulator -avd test -no-audio -no-window -screen no-touch &
 adb wait-for-device
 
 echo "Move to the root directory of the repo…"

--- a/.kokoro/deploy-build-test.sh
+++ b/.kokoro/deploy-build-test.sh
@@ -19,24 +19,6 @@ set -e
 # Save starting directory. The script needs it later.
 cwd=$(pwd)
 
-echo "Setting up speech translation microservice…"
-
-git clone https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git github/nodejs-docs-samples
-export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
-export GCLOUD_PROJECT=nodejs-docs-samples-tests
-export GCF_REGION=us-central1
-export NODE_ENV=development
-export FUNCTIONS_TOPIC=integration-tests-instance
-export FUNCTIONS_BUCKET=$GCLOUD_PROJECT
-gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
-cd ./github/nodejs-docs-samples/functions/speech-to-speech/functions
-env
-gcloud components update
-gcloud --version
-gcloud beta functions deploy speechTranslate --runtime nodejs8 --trigger-http \
-    --update-env-vars ^:^OUTPUT_BUCKET=playchat-c5cc70f6-61ed-4640-91be-996721838560:SUPPORTED_LANGUAGE_CODES=en,es,fr
-
 echo "Setting up Android environment…"
 cd ${cwd}
 if [ ! -d ${HOME}/android-sdk ]; then
@@ -67,6 +49,25 @@ echo "Start the emulator…"
 cd ${ANDROID_HOME}/emulator
 emulator -avd test -no-audio -no-window -screen no-touch &
 adb wait-for-device
+
+echo "Setting up speech translation microservice…"
+
+git clone https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git github/nodejs-docs-samples
+export QT_DEBUG_PLUGINS=1
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
+export GCLOUD_PROJECT=nodejs-docs-samples-tests
+export GCF_REGION=us-central1
+export NODE_ENV=development
+export FUNCTIONS_TOPIC=integration-tests-instance
+export FUNCTIONS_BUCKET=$GCLOUD_PROJECT
+gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
+gcloud config set project $GCLOUD_PROJECT
+cd ./github/nodejs-docs-samples/functions/speech-to-speech/functions
+env
+gcloud components update
+gcloud --version
+gcloud beta functions deploy speechTranslate --runtime nodejs8 --trigger-http \
+    --update-env-vars ^:^OUTPUT_BUCKET=playchat-c5cc70f6-61ed-4640-91be-996721838560:SUPPORTED_LANGUAGE_CODES=en,es,fr
 
 echo "Move to the root directory of the repo…"
 cd ${cwd}/github/firebase-android-client

--- a/.kokoro/deploy-build-test.sh
+++ b/.kokoro/deploy-build-test.sh
@@ -60,7 +60,7 @@ cd ${ANDROID_HOME}/tools/bin
 echo "no" | ./avdmanager create avd -n test -k "system-images;android-27;default;x86_64"
 echo ""
 echo "Start the emulator…"
-cd ..
+cd ${ANDROID_HOME}/emulator
 emulator -avd test -no-audio -no-window &
 adb wait-for-device
 


### PR DESCRIPTION
To fix the following error message:

```
This application failed to start because no Qt platform plugin could be initialized.
```